### PR TITLE
Show autocomplete suggestions in predictive text bar

### DIFF
--- a/src/qmozview_p.h
+++ b/src/qmozview_p.h
@@ -136,6 +136,8 @@ public:
 
     QPointF renderingOffset() const;
 
+    void applyAutoCorrect();
+
 public Q_SLOTS:
     void onCompositorCreated();
     void updateLoaded();
@@ -228,6 +230,8 @@ protected:
     QMap<uint, QPair<QJSValue, QJSValue> > mPendingJSCalls;
     uint mNextJSCallId;
     QString mHttpUserAgent;
+    bool mAutoCompleteActive;
+    QStringList mAutoCompleteList;
 
     DirtyState mDirtyState;
 


### PR DESCRIPTION
**Moved from [gitlab](https://git.sailfishos.org/mer-core/qtmozembed/merge_requests/101).**

Present form autocomplete suggestions in the predictive text bar.

Currently only login form username suggestions are exposed as
autocomplete suggestions by the engine.