### PR TITLE
Revert Drop rendering guards until engine statuses are reported correctly. JB#55286 OMP#JOLLA-310

### DIFF
--- a/src/qmozwindow.cpp
+++ b/src/qmozwindow.cpp
@@ -68,10 +68,7 @@ void QMozWindow::getPlatformImage(const std::function<void(void *image, int widt
 
 void QMozWindow::suspendRendering()
 {
-    // Revert this in context of JB#55286
-#if 0
     d->mWindow->SuspendRendering();
-#endif
 }
 
 void QMozWindow::resumeRendering()

--- a/src/qmozwindow_p.cpp
+++ b/src/qmozwindow_p.cpp
@@ -178,17 +178,12 @@ void QMozWindowPrivate::getGLXContext(void *&context, void *&surface)
 
 bool QMozWindowPrivate::setReadyToPaint(bool ready)
 {
-    Q_UNUSED(ready);
-    return true;
-    // Revert this in context of JB#55286
-#if 0
     QMutexLocker lock(&mReadyToPaintMutex);
     if (mReadyToPaint != ready) {
         mReadyToPaint = ready;
         return true;
     }
     return false;
-#endif
 }
 
 void QMozWindowPrivate::WindowInitialized()
@@ -219,9 +214,6 @@ void QMozWindowPrivate::CompositingFinished()
 
 bool QMozWindowPrivate::PreRender()
 {
-    return true;
-#if 0
     QMutexLocker lock(&mReadyToPaintMutex);
     return mReadyToPaint;
-#endif
 }


### PR DESCRIPTION
…

This reverts commit 5482758178d33ca621c80146e5f89c8fef61d02a.

With https://github.com/sailfishos/gecko-dev/pull/44 applied a MozAfterPaint is being delivered after xulrunner has composited the web page and it can be displayed resulting in setReadyToPaint being called.