### PR TITLE
[qtmozembed] Emit drawOverlay from CompositingFinished. Fixes JB#55709 OMP#JOLLA-404

### DIFF
--- a/src/qmozwindow_p.cpp
+++ b/src/qmozwindow_p.cpp
@@ -209,6 +209,7 @@ void QMozWindowPrivate::CompositorCreated()
 
 void QMozWindowPrivate::CompositingFinished()
 {
+    q.drawOverlay(QRect(0, 0, mSize.width(), mSize.height()));
     q.compositingFinished();
 }
 


### PR DESCRIPTION
DrawWindowOverlay no longer exists in nsBaseWidget [1]. CompositingFinished [2] is also called from the gecko compositor thread at the Render [3]. Hence, this will give us the same end result.

See also https://github.com/sailfishos/gecko-dev/pull/66

[1]
https://github.com/sailfishos/gecko-dev/blob/sailfishos-esr60/widget/nsBaseWidget.h#L453

[2]
https://github.com/sailfishos/gecko-dev/blob/sailfishos-esr78/embedding/embedlite/embedshared/nsWindow.cpp#L272

[3]
https://github.com/sailfishos-mirror/gecko-dev/blob/esr78/gfx/layers/composite/LayerManagerComposite.cpp#L1273