### PR TITLE
Reset domContentLoaded during reset

### DIFF
--- a/src/qmozview_p.cpp
+++ b/src/qmozview_p.cpp
@@ -372,7 +372,7 @@ void QMozViewPrivate::updateMoving(bool moving)
     }
 }
 
-void QMozViewPrivate::resetPainted()
+void QMozViewPrivate::reset()
 {
     if (mIsPainted) {
         mIsPainted = false;
@@ -406,7 +406,7 @@ void QMozViewPrivate::goBack()
     if (!mViewInitialized)
         return;
 
-    resetPainted();
+    reset();
     mView->GoBack();
 }
 
@@ -415,7 +415,7 @@ void QMozViewPrivate::goForward()
     if (!mViewInitialized)
         return;
 
-    resetPainted();
+    reset();
     mView->GoForward();
 }
 
@@ -431,7 +431,7 @@ void QMozViewPrivate::reload()
     if (!mViewInitialized)
         return;
 
-    resetPainted();
+    reset();
     mView->Reload(false);
 }
 
@@ -448,7 +448,7 @@ void QMozViewPrivate::load(const QString &url)
     qCDebug(lcEmbedLiteExt) << "url:" << url.toUtf8().data();
 #endif
     mProgress = 0;
-    resetPainted();
+    reset();
 
     if (mDOMContentLoaded) {
         mDOMContentLoaded = false;
@@ -939,7 +939,7 @@ void QMozViewPrivate::OnLoadStarted(const char *aLocation)
 {
     Q_UNUSED(aLocation);
 
-    resetPainted();
+    reset();
 
     if (!mIsLoading) {
         mIsLoading = true;

--- a/src/qmozview_p.cpp
+++ b/src/qmozview_p.cpp
@@ -378,6 +378,11 @@ void QMozViewPrivate::reset()
         mIsPainted = false;
         mViewIface->firstPaint(-1, -1);
     }
+
+    if (mDOMContentLoaded) {
+        mDOMContentLoaded = false;
+        mViewIface->domContentLoadedChanged();
+    }
 }
 
 void QMozViewPrivate::setSize(const QSizeF &size)
@@ -449,12 +454,6 @@ void QMozViewPrivate::load(const QString &url)
 #endif
     mProgress = 0;
     reset();
-
-    if (mDOMContentLoaded) {
-        mDOMContentLoaded = false;
-        mViewIface->domContentLoadedChanged();
-    }
-
     mView->LoadURL(url.toUtf8().data());
 }
 

--- a/src/qmozview_p.cpp
+++ b/src/qmozview_p.cpp
@@ -383,6 +383,12 @@ void QMozViewPrivate::reset()
         mDOMContentLoaded = false;
         mViewIface->domContentLoadedChanged();
     }
+
+    // In case we had dynamic toolbar height set, mark it dirty
+    // to get it re-applied.
+    if (mDynamicToolbarHeight > 0) {
+        mDirtyState |= DirtyDynamicToolbarHeight;
+    }
 }
 
 void QMozViewPrivate::setSize(const QSizeF &size)

--- a/src/qmozview_p.cpp
+++ b/src/qmozview_p.cpp
@@ -348,7 +348,7 @@ void QMozViewPrivate::handleTouchEnd(bool &draggingChanged, bool &pinchingChange
     }
 }
 
-void QMozViewPrivate::resetState()
+void QMozViewPrivate::resetTouchState()
 {
     // Invalid initial drag start Y.
     mDragStartY = -1.0;
@@ -576,7 +576,7 @@ void QMozViewPrivate::timerEvent(QTimerEvent *event)
         qreal offsetY = mScrollableOffset.y();
         qreal offsetX = mScrollableOffset.x();
         if (offsetX == mOffsetX && offsetY == mOffsetY) {
-            resetState();
+            resetTouchState();
             q->killTimer(mMovingTimerId);
             mMovingTimerId = 0;
         }
@@ -1253,7 +1253,7 @@ void QMozViewPrivate::touchEvent(QTouchEvent *event)
             mPinching = true;
             pinchingChanged = true;
         }
-        resetState();
+        resetTouchState();
     } else if (event->type() == QEvent::TouchUpdate) {
         Q_ASSERT(touchPointsCount > 0);
         if (!mDragging) {
@@ -1293,7 +1293,7 @@ void QMozViewPrivate::touchEvent(QTouchEvent *event)
             updateMoving(mCanFlick);
         } else {
             // From dragging (panning) end to clean state
-            resetState();
+            resetTouchState();
         }
     } else {
         updateMoving(mDragging);

--- a/src/qmozview_p.cpp
+++ b/src/qmozview_p.cpp
@@ -401,6 +401,40 @@ void QMozViewPrivate::setScreenProperties(int depth, qreal density, qreal dpi)
     }
 }
 
+void QMozViewPrivate::goBack()
+{
+    if (!mViewInitialized)
+        return;
+
+    resetPainted();
+    mView->GoBack();
+}
+
+void QMozViewPrivate::goForward()
+{
+    if (!mViewInitialized)
+        return;
+
+    resetPainted();
+    mView->GoForward();
+}
+
+void QMozViewPrivate::stop()
+{
+    if (!mViewInitialized)
+        return;
+    mView->StopLoad();
+}
+
+void QMozViewPrivate::reload()
+{
+    if (!mViewInitialized)
+        return;
+
+    resetPainted();
+    mView->Reload(false);
+}
+
 void QMozViewPrivate::load(const QString &url)
 {
     if (url.isEmpty())

--- a/src/qmozview_p.h
+++ b/src/qmozview_p.h
@@ -97,7 +97,7 @@ public:
     void handleTouchEnd(bool &draggingChanged, bool &pinchingChanged);
     void resetState();
     void updateMoving(bool moving);
-    void resetPainted();
+    void reset();
     void receiveInputEvent(const mozilla::embedlite::EmbedTouchInput &event);
     void setHttpUserAgent(const QString &httpUserAgent);
     QString httpUserAgent() const;

--- a/src/qmozview_p.h
+++ b/src/qmozview_p.h
@@ -95,7 +95,7 @@ public:
     void updateScrollArea(unsigned int aWidth, unsigned int aHeight, float aPosX, float aPosY);
     void testFlickingMode(QTouchEvent *event);
     void handleTouchEnd(bool &draggingChanged, bool &pinchingChanged);
-    void resetState();
+    void resetTouchState();
     void updateMoving(bool moving);
     void reset();
     void receiveInputEvent(const mozilla::embedlite::EmbedTouchInput &event);

--- a/src/qmozview_p.h
+++ b/src/qmozview_p.h
@@ -113,6 +113,10 @@ public:
     void setSize(const QSizeF &size);
     void setScreenProperties(int depth, qreal density, qreal dpi);
 
+    void goBack();
+    void goForward();
+    void stop();
+    void reload();
     void load(const QString &url);
     void loadFrameScript(const QString &frameScript);
     void addMessageListener(const std::string &name);

--- a/src/qopenglwebpage.cpp
+++ b/src/qopenglwebpage.cpp
@@ -524,31 +524,22 @@ void QOpenGLWebPage::loadText(const QString &text, const QString &mimeType)
 
 void QOpenGLWebPage::goBack()
 {
-    if (!d->mViewInitialized)
-        return;
-    d->mView->GoBack();
+    d->goBack();
 }
 
 void QOpenGLWebPage::goForward()
 {
-    if (!d->mViewInitialized)
-        return;
-    d->mView->GoForward();
+    d->goForward();
 }
 
 void QOpenGLWebPage::stop()
 {
-    if (!d->mViewInitialized)
-        return;
-    d->mView->StopLoad();
+    d->stop();
 }
 
 void QOpenGLWebPage::reload()
 {
-    if (!d->mViewInitialized)
-        return;
-    d->resetPainted();
-    d->mView->Reload(false);
+    d->reload();
 }
 
 void QOpenGLWebPage::load(const QString &url)

--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -688,36 +688,22 @@ void QuickMozView::loadText(const QString &text, const QString &mimeType)
 
 void QuickMozView::goBack()
 {
-    if (!d->mViewInitialized)
-        return;
-
-    d->resetPainted();
-    d->mView->GoBack();
+    d->goBack();
 }
 
 void QuickMozView::goForward()
 {
-    if (!d->mViewInitialized)
-        return;
-
-    d->resetPainted();
-    d->mView->GoForward();
+    d->goForward();
 }
 
 void QuickMozView::stop()
 {
-    if (!d->mViewInitialized)
-        return;
-    d->mView->StopLoad();
+    d->stop();
 }
 
 void QuickMozView::reload()
 {
-    if (!d->mViewInitialized)
-        return;
-
-    d->resetPainted();
-    d->mView->Reload(false);
+    d->reload();
 }
 
 void QuickMozView::load(const QString &url)


### PR DESCRIPTION
Reset is called upon goBack, goForward, reload, and load.

This PR contains 4 commits

1. Move goBack, goForward, stop, and reload to private class.
2. Change resetPainted as generic reset
3. Rename resetState to resetTouchState
4. Mark dynamic toolbar height dirty on reset

After this PR, dynamic toolbar is reset when going back and forth, load, and reload.

See also https://github.com/sailfishos/sailfish-browser/pull/941
