### PR TITLE
[qtmozembed] Drop rootScrollFrame argument. Fixes JB#56312 OMP#JOLLA-530

### DIFF
--- a/src/qmozview_p.cpp
+++ b/src/qmozview_p.cpp
@@ -1183,13 +1183,8 @@ void QMozViewPrivate::OnDynamicToolbarHeightChanged()
     mViewIface->dynamicToolbarHeightChanged();
 }
 
-bool QMozViewPrivate::HandleScrollEvent(bool aIsRootScrollFrame, const gfxRect &aContentRect, const gfxSize &aScrollableSize)
+bool QMozViewPrivate::HandleScrollEvent(const gfxRect &aContentRect, const gfxSize &aScrollableSize)
 {
-    // aIsRootScrollFrame makes it possible to handle chrome gesture also in case that we have
-    // an iframe that is of the size of the screen. We may need to add still a scrollable layer id or similar.
-    if (!aIsRootScrollFrame)
-        return false;
-
     if (mContentRect.x() != aContentRect.x || mContentRect.y() != aContentRect.y ||
             mContentRect.width() != aContentRect.width ||
             mContentRect.height() != aContentRect.height) {

--- a/src/qmozview_p.h
+++ b/src/qmozview_p.h
@@ -83,7 +83,7 @@ public:
     bool HandleLongTap(const nsIntPoint &aPoint) override;
     bool HandleSingleTap(const nsIntPoint &aPoint) override;
     bool HandleDoubleTap(const nsIntPoint &aPoint) override;
-    bool HandleScrollEvent(bool aIsRootScrollFrame, const gfxRect &aContentRect, const gfxSize &aScrollableSize) override;
+    bool HandleScrollEvent(const gfxRect &aContentRect, const gfxSize &aScrollableSize) override;
     void OnHttpUserAgentUsed(const char16_t *aHttpUserAgent);
 
     // Starting from here these are QMozViewPrivate methods.


### PR DESCRIPTION
The rootScrollFrame no longer exists in the EmbedLiteViewListener.

See also:
https://github.com/sailfishos/gecko-dev/pull/119