### PR TITLE
Cleanup unit tests a bit

### DIFF
--- a/tests/components/tests/content/testHelper.js
+++ b/tests/components/tests/content/testHelper.js
@@ -4,20 +4,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource://gre/modules/Geometry.jsm");
-Cu.import("resource://gre/modules/AddonManager.jsm");
-Cu.import("resource://gre/modules/FileUtils.jsm");
-
-let HTMLSelectElement = Ci.nsIDOMHTMLSelectElement;
-let HTMLLabelElement = Ci.nsIDOMHTMLLabelElement;
-let HTMLIFrameElement = Ci.nsIDOMHTMLIFrameElement;
-let HTMLFrameElement = Ci.nsIDOMHTMLFrameElement;
-
-XPCOMUtils.defineLazyServiceGetter(this, "DOMUtils",
-  "@mozilla.org/inspector/dom-utils;1", "inIDOMUtils");
-
 XPCOMUtils.defineLazyServiceGetter(Services, "embedlite",
                                     "@mozilla.org/embedlite-app-service;1",
                                     "nsIEmbedAppService");
@@ -33,8 +19,8 @@ function TestHelper() {
 }
 
 TestHelper.prototype = {
-  QueryInterface: XPCOMUtils.generateQI([Ci.nsIObserver,
-                                         Ci.nsISupportsWeakReference]),
+  QueryInterface: ChromeUtils.generateQI([Ci.nsIObserver,
+                                          Ci.nsISupportsWeakReference]),
 
   _fastFind: null,
   _init: function()


### PR DESCRIPTION
There are multiple unit test cases failing but at least testHelper.js
loads now.

I was originally planning to add unit test case for contentWidth and contentHeight but as there are cases failing didn't want to do that in context of JB#56313 / OMP#JOLLA-531. Thus, just this small cleanup.

Added viewport related infos to https://github.com/sailfishos/sailfish-components-webview/pull/138