### PR TITLE
[qtmozembed] Add preference type to the setPreference. JB#56638 OMP#JOLLA-573

### DIFF
--- a/src/qmozenginesettings.cpp
+++ b/src/qmozenginesettings.cpp
@@ -208,7 +208,7 @@ void QMozEngineSettingsPrivate::enableLowPrecisionBuffers(bool enabled)
     setPreference(QStringLiteral("layers.low-precision-buffer"), QVariant::fromValue<bool>(enabled));
 }
 
-void QMozEngineSettingsPrivate::setPreference(const QString &key, const QVariant &value)
+void QMozEngineSettingsPrivate::setPreference(const QString &key, const QVariant &value, QMozEngineSettings::PreferenceType preferenceType)
 {
     qCDebug(lcEmbedLiteExt) << "name:" << key.toUtf8().data() << ", type:" << value.type() << ", user type:" << value.userType();
 
@@ -220,24 +220,37 @@ void QMozEngineSettingsPrivate::setPreference(const QString &key, const QVariant
 
     mozilla::embedlite::EmbedLiteApp *app = QMozContext::instance()->GetApp();
 
-    int type = value.type();
-    switch (type) {
-    case QMetaType::QString:
-    case QMetaType::Float:
-    case QMetaType::Double:
-        app->SetCharPref(key.toUtf8().data(), value.toString().toUtf8().data());
-        break;
-    case QMetaType::Int:
-    case QMetaType::UInt:
-    case QMetaType::LongLong:
-    case QMetaType::ULongLong:
-        app->SetIntPref(key.toUtf8().data(), value.toInt());
-        break;
-    case QMetaType::Bool:
+    switch (preferenceType) {
+    case QMozEngineSettings::BoolPref:
         app->SetBoolPref(key.toUtf8().data(), value.toBool());
         break;
+    case QMozEngineSettings::StringPref:
+        app->SetCharPref(key.toUtf8().data(), value.toString().toUtf8().data());
+        break;
+    case QMozEngineSettings::IntPref:
+        app->SetIntPref(key.toUtf8().data(), value.toInt());
+        break;
     default:
-        qCWarning(lcEmbedLiteExt) << "Unknown pref" << key << "value" << value << "type:" << value.type() << "userType:" << value.userType();
+        int type = value.type();
+        switch (type) {
+        case QMetaType::QString:
+        case QMetaType::Float:
+        case QMetaType::Double:
+            app->SetCharPref(key.toUtf8().data(), value.toString().toUtf8().data());
+            break;
+        case QMetaType::Int:
+        case QMetaType::UInt:
+        case QMetaType::LongLong:
+        case QMetaType::ULongLong:
+            app->SetIntPref(key.toUtf8().data(), value.toInt());
+            break;
+        case QMetaType::Bool:
+            app->SetBoolPref(key.toUtf8().data(), value.toBool());
+            break;
+        default:
+            qCWarning(lcEmbedLiteExt) << "Unknown pref" << key << "value" << value << "type:" << value.type() << "userType:" << value.userType();
+        }
+        break;
     }
 }
 
@@ -510,8 +523,8 @@ void QMozEngineSettings::enableLowPrecisionBuffers(bool enabled)
     d->enableLowPrecisionBuffers(enabled);
 }
 
-void QMozEngineSettings::setPreference(const QString &key, const QVariant &value)
+void QMozEngineSettings::setPreference(const QString &key, const QVariant &value, PreferenceType preferenceType)
 {
     Q_D(QMozEngineSettings);
-    d->setPreference(key, value);
+    d->setPreference(key, value, preferenceType);
 }

--- a/src/qmozenginesettings.h
+++ b/src/qmozenginesettings.h
@@ -47,6 +47,15 @@ public:
     };
     Q_ENUM(CookieBehavior)
 
+    // See https://github.com/sailfishos-mirror/gecko-dev/blob/esr78/modules/libpref/nsIPrefBranch.idl
+    enum PreferenceType {
+        UnknownPref = 0,
+        StringPref = 32,
+        IntPref = 64,
+        BoolPref = 128
+    };
+    Q_ENUM(PreferenceType)
+
     bool isInitialized() const;
 
     bool autoLoadImages() const;
@@ -79,7 +88,7 @@ public:
     void enableLowPrecisionBuffers(bool enabled);
 
     // Low-level API to set engine preferences.
-    Q_INVOKABLE void setPreference(const QString &key, const QVariant &value);
+    Q_INVOKABLE void setPreference(const QString &key, const QVariant &value, PreferenceType preferenceType = UnknownPref);
 
 Q_SIGNALS:
     void autoLoadImagesChanged();

--- a/src/qmozenginesettings_p.h
+++ b/src/qmozenginesettings_p.h
@@ -58,7 +58,7 @@ public:
     void enableProgressivePainting(bool enabled);
     void enableLowPrecisionBuffers(bool enabled);
 
-    void setPreference(const QString &key, const QVariant &value);
+    void setPreference(const QString &key, const QVariant &value, QMozEngineSettings::PreferenceType preferenceType = QMozEngineSettings::UnknownPref) ;
     void requestPreference(const QString &key);
 
     bool isInitialized() const;


### PR DESCRIPTION
The preference type is used as a hint when passing preference value
towards the engine.