### PR TITLE
[qtmozembed] Bring back previous setPreference and overload it. JB#56638 OMP#JOLLA-573

### DIFF
--- a/src/qmozenginesettings.cpp
+++ b/src/qmozenginesettings.cpp
@@ -523,6 +523,12 @@ void QMozEngineSettings::enableLowPrecisionBuffers(bool enabled)
     d->enableLowPrecisionBuffers(enabled);
 }
 
+void QMozEngineSettings::setPreference(const QString &key, const QVariant &value)
+{
+    Q_D(QMozEngineSettings);
+    d->setPreference(key, value);
+}
+
 void QMozEngineSettings::setPreference(const QString &key, const QVariant &value, PreferenceType preferenceType)
 {
     Q_D(QMozEngineSettings);

--- a/src/qmozenginesettings.h
+++ b/src/qmozenginesettings.h
@@ -88,7 +88,8 @@ public:
     void enableLowPrecisionBuffers(bool enabled);
 
     // Low-level API to set engine preferences.
-    Q_INVOKABLE void setPreference(const QString &key, const QVariant &value, PreferenceType preferenceType = UnknownPref);
+    Q_INVOKABLE void setPreference(const QString &key, const QVariant &value);
+    Q_INVOKABLE void setPreference(const QString &key, const QVariant &value, PreferenceType preferenceType);
 
 Q_SIGNALS:
     void autoLoadImagesChanged();


### PR DESCRIPTION
This way we do not break C++ usage of the setPreference.