### PR TITLE
[qtmozembed] Fix text input with xt9. JB#56870

### DIFF
--- a/src/qmozview_p.cpp
+++ b/src/qmozview_p.cpp
@@ -657,7 +657,6 @@ void QMozViewPrivate::inputMethodEvent(QInputMethodEvent *event)
                             << ", replSt:" << event->replacementStart();
 #endif
 
-    mPreedit = !event->preeditString().isEmpty();
     if (mViewInitialized) {
         uint16_t charCode = (event->commitString().size() == 1 && event->commitString()[0].isPrint())
                           ? (int32_t)event->commitString()[0].unicode()
@@ -671,7 +670,7 @@ void QMozViewPrivate::inputMethodEvent(QInputMethodEvent *event)
             qGuiApp->inputMethod()->reset();
 
         } else {
-            if (event->commitString().isEmpty() || event->commitString().size() > 1) {
+            if (mPreedit || event->commitString().isEmpty() || event->commitString().size() > 1) {
                 mView->SendTextEvent(event->commitString().toUtf8().data(), event->preeditString().toUtf8().data(), event->replacementStart(), event->replacementLength());
             } else {
                 mView->SendKeyPress(0, 0, charCode);
@@ -679,6 +678,7 @@ void QMozViewPrivate::inputMethodEvent(QInputMethodEvent *event)
             }
         }
     }
+    mPreedit = !event->preeditString().isEmpty();
 }
 
 void QMozViewPrivate::keyPressEvent(QKeyEvent *event)


### PR DESCRIPTION
QMozViewPrivate::touchEvent issues the commit when screen is tapped and that sent the extra keypress with xt9. I didn't notice any problems in the browser test pages with this and also https://webk.telegram.org works.