### PR TITLE
Split and fix tst_searchengine

### DIFF
--- a/tests/auto/shared/searchengine/test.xml
+++ b/tests/auto/shared/searchengine/test.xml
@@ -6,6 +6,6 @@
 <ShortName>QMOZTest</ShortName>
 <Description>Qt Moz Embed search</Description>
 <InputEncoding>UTF-8</InputEncoding>
-<Url type="text/html" method="GET" template="https://webhook/?search={searchTerms}"/>
+<Url type="text/html" method="GET" template="https://qmoztest/?search={searchTerms}"/>
 <SearchForm>https://webhook/</SearchForm>
 </SearchPlugin>


### PR DESCRIPTION
Contains two commits

- Wait engine to load in initTestCase
- Split checkDefaultSearch of tst_searchengine to three

There are separate test functions for adding search engine, changing default,
and doing a search.

The dedicated test.xml is updated so that url is like qmoztest. This
way we can more easily compare url value. Actual search result is
irrelevant.

Further, test_003_searchFromWeb is skipped if there's no network
connection as it would time out easily when trying to do http get
without network to none existing service.

Requires:
https://github.com/sailfishos/embedlite-components/pull/92

Whilst running tests locally noticed that test runner looks up installed search engines always from /home/defaultuser/.local/share/org.sailfishos/browser/searchEngines regardless of the active profile. The should be coming from here: https://github.com/sailfishos/gecko-dev/blob/master/embedding/embedlite/utils/DirProvider.cpp#L56 and there should be simple fix. Building engine with a fix applied and will open that PR shortly. 