### PR TITLE
[qtmozembed] Prevent touch event coordinates fluctuation. Fixes JB#57776

### DIFF
--- a/src/qmozview_p.h
+++ b/src/qmozview_p.h
@@ -202,7 +202,8 @@ protected:
     QPointF mLastPos;
     QPointF mSecondLastPos;
     QPointF mLastStationaryPos;
-    QMap<int, QPointF> mActiveTouchPoints;
+    // <id, <pos, timestamp>>
+    QMap<int, QPair<QPointF, ulong>> mActiveTouchPoints;
     bool mCanFlick;
     bool mPendingTouchEvent;
     QString mUrl;


### PR DESCRIPTION
Scrolling pages in the browser on slow devices periodically spontaneously
changes direction. Dropping points whose arrival interval is less than 2 ms
solves this problem.