### PR TITLE
[qtmozembed] Use physicalDotsPerInch for EmbedLiteView dpi. Fixes JB#56899

### DIFF
--- a/src/qmozview_p.cpp
+++ b/src/qmozview_p.cpp
@@ -156,7 +156,6 @@ QMozViewPrivate::QMozViewPrivate(IMozQViewIface *aViewIface, QObject *publicPtr)
     , mOffsetY(0.0)
     , mHasCompositor(false)
     , mDepth(0)
-    , mDensity(0.0)
     , mDpi(0.0)
     , mNextJSCallId(0)
     , mAutoCompleteActive(false)
@@ -414,16 +413,15 @@ void QMozViewPrivate::setSize(const QSizeF &size)
     }
 }
 
-void QMozViewPrivate::setScreenProperties(int depth, qreal density, qreal dpi)
+void QMozViewPrivate::setScreenProperties(int depth, qreal dpi)
 {
     Q_ASSERT_X(mView, __PRETTY_FUNCTION__, "EmbedLiteView must be created by now");
     mDepth = depth;
-    mDensity = density;
     mDpi = dpi;
     if (!mHasCompositor) {
         mDirtyState |= DirtyScreenProperties;
     } else {
-        mView->SetScreenProperties(mDepth, mDensity, mDpi);
+        mView->SetScreenProperties(mDepth, mDpi, mDpi);
     }
 }
 
@@ -818,7 +816,7 @@ void QMozViewPrivate::onCompositorCreated()
 {
     mHasCompositor = true;
     if (mDirtyState & DirtyScreenProperties) {
-        mView->SetScreenProperties(mDepth, mDensity, mDpi);
+        mView->SetScreenProperties(mDepth, mDpi, mDpi);
         mDirtyState &= ~DirtyScreenProperties;
     }
 }
@@ -859,8 +857,7 @@ void QMozViewPrivate::createView()
         mView = mContext->GetApp()->CreateView(win, mParentID, mParentBrowsingContext, mPrivateMode, mDesktopMode);
         mView->SetListener(this);
         setScreenProperties(QGuiApplication::primaryScreen()->depth(),
-                            QGuiApplication::primaryScreen()->physicalDotsPerInch(),
-                            QGuiApplication::primaryScreen()->logicalDotsPerInch());
+                            QGuiApplication::primaryScreen()->physicalDotsPerInch());
 
         if (mozView) {
             connect(mMozWindow.data(), &QMozWindow::compositingFinished,

--- a/src/qmozview_p.h
+++ b/src/qmozview_p.h
@@ -111,7 +111,7 @@ public:
     bool domContentLoaded() const;
 
     void setSize(const QSizeF &size);
-    void setScreenProperties(int depth, qreal density, qreal dpi);
+    void setScreenProperties(int depth, qreal dpi);
 
     QUrl url() const;
     bool isUrlResolved() const;
@@ -244,7 +244,6 @@ protected:
     bool mHasCompositor;
     QMozSecurity mSecurity;
     int mDepth;
-    qreal mDensity;
     qreal mDpi;
     // Pair of success and error callbacks.
     QMap<uint, QPair<QJSValue, QJSValue> > mPendingJSCalls;


### PR DESCRIPTION
This fixes regression caused by commit sha1 b65152d7. Before that
change QtMozEmbed read primary screen's physicalDotsPerInch and set
that as a dpi of the EmbedLiteView. The set dpi is set for to the APZCTreeManager.
When going further down, the AsyncPanZoomController calculates touch start
tolerance back like StaticPrefs::apz_touch_start_tolerance() * GetDPI().
This apz_touch_start_tolerance is the static getter of apz.touch_start_tolerance preference.

Embedlite apz.touch_start_tolerance (0.0762785) ballpark matches
to the Android FF (0.06 - mobile.js). Meaning that formulate that is used in
sailfish-components-webview is good enough.

Signed-off-by: Raine Makelainen <raine.makelainen@jolla.com>