### PR TITLE
Avoid skipping pages without user interaction on goBack/goForward

### DIFF
--- a/src/qmozcontext.cpp
+++ b/src/qmozcontext.cpp
@@ -103,7 +103,7 @@ QMozContextPrivate::QMozContextPrivate(QObject *parent)
     , mViewCreator(nullptr)
     , mMozWindow(nullptr)
 {
-    qCDebug(lcEmbedLiteExt) << "Create new Context:" << (void *)this << ", parent:" << (void *)parent << getenv("GRE_HOME");;
+    qCDebug(lcEmbedLiteExt) << "Create new Context:" << (void *)this << ", parent:" << (void *)parent << getenv("GRE_HOME");
 
     platform_egl_workaround_open();
 

--- a/src/qmozopenglwebpage.cpp
+++ b/src/qmozopenglwebpage.cpp
@@ -537,7 +537,7 @@ void QMozOpenGLWebPage::reload()
     d->reload();
 }
 
-void QMozOpenGLWebPage::load(const QString &url, const bool &fromExternal)
+void QMozOpenGLWebPage::load(const QString &url, bool fromExternal)
 {
     d->load(url, fromExternal);
 }

--- a/src/qmozopenglwebpage.cpp
+++ b/src/qmozopenglwebpage.cpp
@@ -517,7 +517,6 @@ void QMozOpenGLWebPage::loadText(const QString &text, const QString &mimeType)
              + QString::fromUtf8(QUrl::toPercentEncoding(text))), false);
 }
 
-
 void QMozOpenGLWebPage::goBack()
 {
     d->goBack();

--- a/src/qmozview_defined_wrapper.h
+++ b/src/qmozview_defined_wrapper.h
@@ -160,7 +160,7 @@ Q_DECLARE_METATYPE(QMozReturnValue) \
     void goForward(); \
     void stop(); \
     void reload(); \
-    void load(const QString&, const bool& fromExternal); \
+    void load(const QString&, bool fromExternal); \
     void sendAsyncMessage(const QString &name, const QVariant &variant); \
     void addMessageListener(const QString &name); \
     void loadFrameScript(const QString &name); \

--- a/src/qmozview_p.cpp
+++ b/src/qmozview_p.cpp
@@ -442,7 +442,7 @@ void QMozViewPrivate::goBack()
         return;
 
     reset();
-    mView->GoBack(true, true);
+    mView->GoBack(false, true);
 }
 
 void QMozViewPrivate::goForward()
@@ -451,7 +451,7 @@ void QMozViewPrivate::goForward()
         return;
 
     reset();
-    mView->GoForward(true, true);
+    mView->GoForward(false, true);
 }
 
 void QMozViewPrivate::stop()

--- a/src/qmozview_p.cpp
+++ b/src/qmozview_p.cpp
@@ -474,7 +474,7 @@ void QMozViewPrivate::reload()
     }
 }
 
-void QMozViewPrivate::load(const QString &url, const bool& fromExternal)
+void QMozViewPrivate::load(const QString &url, bool fromExternal)
 {
     if (url.isEmpty())
         return;

--- a/src/qmozview_p.h
+++ b/src/qmozview_p.h
@@ -119,7 +119,7 @@ public:
     void goForward();
     void stop();
     void reload();
-    void load(const QString &url, const bool& fromExternal);
+    void load(const QString &url, bool fromExternal);
     void loadFrameScript(const QString &frameScript);
     void addMessageListener(const std::string &name);
     void addMessageListeners(const std::vector<std::string> &messageNamesList);

--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -109,8 +109,7 @@ QuickMozView::~QuickMozView()
     d = nullptr;
 }
 
-void
-QuickMozView::SetIsActive(bool aIsActive)
+void QuickMozView::SetIsActive(bool aIsActive)
 {
     if (QThread::currentThread() == thread() && d->mView) {
         d->mView->SetIsActive(aIsActive);
@@ -165,8 +164,7 @@ void QuickMozView::geometryChanged(const QRectF &newGeometry, const QRectF &oldG
     QQuickItem::geometryChanged(newGeometry, oldGeometry);
 }
 
-QSGNode *
-QuickMozView::updatePaintNode(QSGNode *oldNode, UpdatePaintNodeData *)
+QSGNode * QuickMozView::updatePaintNode(QSGNode *oldNode, UpdatePaintNodeData *)
 {
     // If the dimensions are entirely invalid return no node.
     if (width() <= 0 || height() <= 0) {
@@ -693,7 +691,8 @@ void QuickMozView::loadHtml(const QString &html, const QUrl &baseUrl)
 
 void QuickMozView::loadText(const QString &text, const QString &mimeType)
 {
-    d->load((QLatin1String("data:") + mimeType + QLatin1String(";charset=utf-8,") + QString::fromUtf8(QUrl::toPercentEncoding(text))), false);
+    d->load((QLatin1String("data:") + mimeType + QLatin1String(";charset=utf-8,")
+             + QString::fromUtf8(QUrl::toPercentEncoding(text))), false);
 }
 
 void QuickMozView::goBack()

--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -715,7 +715,7 @@ void QuickMozView::reload()
     d->reload();
 }
 
-void QuickMozView::load(const QString &url, const bool &fromExternal)
+void QuickMozView::load(const QString &url, bool fromExternal)
 {
     d->load(url, fromExternal);
 }

--- a/tests/auto/desktop-qt5/useragent/tst_useragent.qml
+++ b/tests/auto/desktop-qt5/useragent/tst_useragent.qml
@@ -23,6 +23,7 @@ TestWindow {
 
     QmlMozView {
         id: webViewport
+
         visible: true
         focus: true
         active: true
@@ -31,6 +32,7 @@ TestWindow {
 
     SignalSpy {
         id: webViewportSpy
+
         target: webViewport
         signalName: "viewInitialized"
     }
@@ -45,16 +47,17 @@ TestWindow {
 
         // Load the new page
         webViewportSpy.clear()
-        webViewport.url = url;
+        webViewport.url = url
         while ((webViewportSpy.count == 0) || webViewport.loading) {
             webViewportSpy.wait()
         }
         testcaseid.compare(webViewport.loading, false)
-        testcaseid.compare(webViewport.loadProgress, 100);
+        testcaseid.compare(webViewport.loadProgress, 100)
     }
 
     TestCase {
         id: testcaseid
+
         name: "tst_useragent"
         when: windowShown
 
@@ -71,7 +74,7 @@ TestWindow {
             webViewport.httpUserAgent = ""
             verify(webViewport.httpUserAgent === "")
             loadPage(test_page)
-            verify(MyScript.wrtWait(function() { return (webViewport.httpUserAgent === ""); }))
+            verify(MyScript.wrtWait(function() { return (webViewport.httpUserAgent === "") }))
             verify(webViewport.httpUserAgent === override_default)
         }
 
@@ -105,7 +108,7 @@ TestWindow {
             // Load the page
             webViewportSpy.signalName = "httpUserAgentChanged"
             webViewportSpy.clear()
-            webViewport.url = test_page;
+            webViewport.url = test_page
 
             // Check the httpUserAgentChanged signal is sent
             webViewportSpy.wait()


### PR DESCRIPTION
Main commit:

    [qtmozembed] Don't skip pages without user interaction on goBack/Forward. JB#62664
    
    The second parameter, added in ESR91, is aRequireUserInteraction.
    Meaning that as true it skipped the pages that had no user interaction.
    
    This broke a sailfish-browser unit tests for forward/backward navigation
    and also made the back button act surprising in the Browser app when
    it started jumping over pages in the history.

Some minor changes while at it.
