### PR TITLE
Skip full shutdown on every unit test

### DIFF
--- a/src/qmozviewcreator.h
+++ b/src/qmozviewcreator.h
@@ -17,8 +17,8 @@ class QMozViewCreator : public QObject
     Q_OBJECT
 
 public:
-    explicit QMozViewCreator(QObject *parent = 0) : QObject(parent) {};
-    virtual ~QMozViewCreator() {};
+    explicit QMozViewCreator(QObject *parent = 0) : QObject(parent) {}
+    virtual ~QMozViewCreator() {}
 
     /*
      * @returns ID of created web view

--- a/tests/qmlmoztestrunner/main.cpp
+++ b/tests/qmlmoztestrunner/main.cpp
@@ -36,11 +36,14 @@
 #include "qmozenginesettings.h"
 #include "testviewcreator.h"
 #include "testhelper.h"
+
+#include <stdio.h>
+#include <unistd.h>
+
 #include <QGuiApplication>
 #include <QtCore/qstring.h>
 #include <QTimer>
 #include <QtQml>
-#include <stdio.h>
 #include <QQuickView>
 #include <QtQuickTest/quicktest.h>
 
@@ -87,6 +90,12 @@ int main(int argc, char **argv)
     });
 
     app.exec();
+
+    // in case there are problems in shutdown (tricky business!), avoid making all the
+    // tests failing and rather have a separate test for that
+    if (qgetenv("FULL_SHUTDOWN").length() == 0) {
+        _exit(ret);
+    }
 
     while (!contextDestroyed) {
         QEventLoop::ProcessEventsFlags flags = QEventLoop::AllEvents | QEventLoop::WaitForMoreEvents;

--- a/tests/qmlmoztestrunner/testhelper.cpp
+++ b/tests/qmlmoztestrunner/testhelper.cpp
@@ -12,10 +12,9 @@
 TestHelper::TestHelper(QObject *parent)
     : QObject(parent)
 {
-
 }
 
-QString TestHelper::getenv(const QString envVarName) const
+QString TestHelper::getenv(const QString &envVarName) const
 {
     return QString(::getenv(envVarName.toUtf8().constData()));
 }

--- a/tests/qmlmoztestrunner/testhelper.h
+++ b/tests/qmlmoztestrunner/testhelper.h
@@ -18,7 +18,7 @@ class TestHelper : public QObject
 public:
     explicit TestHelper(QObject *parent = nullptr);
 
-    Q_INVOKABLE QString getenv(const QString envVarName) const;
+    Q_INVOKABLE QString getenv(const QString &envVarName) const;
 };
 
 #endif

--- a/tests/qmlmoztestrunner/testviewcreator.cpp
+++ b/tests/qmlmoztestrunner/testviewcreator.cpp
@@ -80,6 +80,5 @@ quint32 TestViewCreator::createView(const quint32 &parentId, const uintptr_t &pa
         emit newViewCreated(nullptr);
     }
 
-
     return uniqueId;
 };

--- a/tests/test-definition/tests.xml
+++ b/tests/test-definition/tests.xml
@@ -14,7 +14,7 @@
                <step>cd /opt/tests/qtmozembed/auto/desktop-qt5/context &amp;&amp; ../../run-tests.sh</step>
            </case>
            <case manual="false" name="unittests-basicview">
-               <step>cd /opt/tests/qtmozembed/auto/desktop-qt5/basicview &amp;&amp; ../../run-tests.sh</step>
+               <step>cd /opt/tests/qtmozembed/auto/desktop-qt5/basicview &amp;&amp; FULL_SHUTDOWN=1 ../../run-tests.sh</step>
            </case>
            <case manual="false" name="unittests-view">
                <step>cd /opt/tests/qtmozembed/auto/desktop-qt5/view &amp;&amp; ../../run-tests.sh</step>


### PR DESCRIPTION
Main commit

    [qtmozembed] Avoid running gecko shutdown on all the unit tests. JB#62626
    
    There is now some problem on the shutdown sequence that makes
    qmlmoztestrunner segfault, making all the unit tests fail
    even if the main case it was intended to test succeeded.
    
    So making the full shutdown now opt-in and having it tested in the
    basicview case. Gets the problem still visible, but not confusing it
    with tests for other functionality.
