### PR TITLE
Remove virtual keyboard height and dead member variable

### DIFF
--- a/src/qmozopenglwebpage.cpp
+++ b/src/qmozopenglwebpage.cpp
@@ -49,9 +49,7 @@ QMozOpenGLWebPage::QMozOpenGLWebPage(QObject *parent)
     : QObject(parent)
     , d(new QMozViewPrivate(new IMozQView<QMozOpenGLWebPage>(*this), this))
     , mCompleted(false)
-    , mSizeUpdateScheduled(false)
     , mThrottlePainting(false)
-    , m_virtualKeyboardHeight(0)
 {
     d->mContext = QMozContext::instance();
 
@@ -202,19 +200,6 @@ void QMozOpenGLWebPage::setThrottlePainting(bool throttle)
         mThrottlePainting = throttle;
         d->setThrottlePainting(throttle);
         Q_EMIT throttlePaintingChanged();
-    }
-}
-
-int QMozOpenGLWebPage::virtualKeyboardHeight() const
-{
-    return m_virtualKeyboardHeight;
-}
-
-void QMozOpenGLWebPage::setVirtualKeyboardHeight(int height)
-{
-    if (height != m_virtualKeyboardHeight) {
-        m_virtualKeyboardHeight = height;
-        Q_EMIT virtualKeyboardHeightChanged();
     }
 }
 

--- a/src/qmozopenglwebpage.h
+++ b/src/qmozopenglwebpage.h
@@ -38,7 +38,6 @@ class QMozOpenGLWebPage : public QObject
     Q_PROPERTY(bool active READ active WRITE setActive NOTIFY activeChanged FINAL)
     Q_PROPERTY(bool loaded READ loaded NOTIFY loadedChanged FINAL)
     Q_PROPERTY(bool throttlePainting READ throttlePainting WRITE setThrottlePainting NOTIFY throttlePaintingChanged FINAL)
-    Q_PROPERTY(int virtualKeyboardHeight WRITE setVirtualKeyboardHeight READ virtualKeyboardHeight NOTIFY virtualKeyboardHeightChanged FINAL)
 
     Q_MOZ_VIEW_PROPERTIES
 
@@ -66,9 +65,6 @@ public:
 
     bool throttlePainting() const;
     void setThrottlePainting(bool);
-
-    int virtualKeyboardHeight() const;
-    void setVirtualKeyboardHeight(int);
 
     void initialize();
 
@@ -101,7 +97,6 @@ Q_SIGNALS:
     void heightChanged();
     void loadedChanged();
     void throttlePaintingChanged();
-    void virtualKeyboardHeightChanged();
     void afterRendering();
 
 private Q_SLOTS:
@@ -115,9 +110,7 @@ private:
     bool mCompleted;
     QList<QWeakPointer<QMozGrabResult> > mGrabResultList;
     QMutex mGrabResultListLock;
-    bool mSizeUpdateScheduled;
     bool mThrottlePainting;
-    int m_virtualKeyboardHeight;
 
     Q_DISABLE_COPY(QMozOpenGLWebPage)
 };

--- a/src/qmozview_p.cpp
+++ b/src/qmozview_p.cpp
@@ -24,10 +24,11 @@
 #include <string>
 #include <codecvt>
 
+#include <sys/time.h>
+
 #include <mozilla/embedlite/EmbedInputData.h>
 #include <mozilla/embedlite/EmbedLiteApp.h>
 #include <mozilla/gfx/Tools.h>
-#include <sys/time.h>
 #include <mozilla/TimeStamp.h>
 
 #include <nsPoint.h>
@@ -197,8 +198,8 @@ void QMozViewPrivate::updateScrollArea(unsigned int aWidth, unsigned int aHeight
         heightChanged = true;
     }
 
-    if (!gfx::FuzzyEqual(mScrollableOffset.x(), aPosX, SCROLL_EPSILON) ||
-            !gfx::FuzzyEqual(mScrollableOffset.y(), aPosY, SCROLL_EPSILON)) {
+    if (!gfx::FuzzyEqual(mScrollableOffset.x(), aPosX, SCROLL_EPSILON)
+            || !gfx::FuzzyEqual(mScrollableOffset.y(), aPosY, SCROLL_EPSILON)) {
 
         mScrollableOffset.setX(aPosX);
         mScrollableOffset.setY(aPosY);
@@ -335,9 +336,9 @@ void QMozViewPrivate::testFlickingMode(QTouchEvent *event)
                 hasMoved = !((tp.pos() - mSecondLastPos).isNull());
             }
 
-            mCanFlick = (qint64(current_timestamp(event) - mLastTimestamp) < MOZVIEW_FLICK_THRESHOLD) &&
-                    (qint64(current_timestamp(event) - mLastStationaryTimestamp) < MOZVIEW_FLICK_THRESHOLD) &&
-                    hasMoved;
+            mCanFlick = (qint64(current_timestamp(event) - mLastTimestamp) < MOZVIEW_FLICK_THRESHOLD)
+                    && (qint64(current_timestamp(event) - mLastStationaryTimestamp) < MOZVIEW_FLICK_THRESHOLD)
+                    && hasMoved;
             mLastStationaryPos = QPointF();
         }
     }
@@ -673,7 +674,8 @@ void QMozViewPrivate::inputMethodEvent(QInputMethodEvent *event)
                           : 0;
         bool ok;
         int asciiNumber = event->commitString().toInt(&ok) + Qt::Key_0;
-        if (ok && (mInputMethodHints & Qt::ImhFormattedNumbersOnly || mInputMethodHints & Qt::ImhDialableCharactersOnly)) {
+        if (ok && (mInputMethodHints & Qt::ImhFormattedNumbersOnly
+                   || mInputMethodHints & Qt::ImhDialableCharactersOnly)) {
             int32_t domKeyCode = MozKey::QtKeyCodeToDOMKeyCode(asciiNumber, Qt::NoModifier);
             mView->SendKeyPress(domKeyCode, 0, charCode);
             mView->SendKeyRelease(domKeyCode, 0, charCode);


### PR DESCRIPTION
No-op property here, just used for internal state keeping in sailfish-browser side. Can have it defined closer to where it's actually used, being simpler and easier to understand.