### PR TITLE
Fix text selection landscape display positions

### DIFF
--- a/src/qmozview_p.cpp
+++ b/src/qmozview_p.cpp
@@ -68,7 +68,7 @@ using namespace mozilla::embedlite;
 #define DOCURI_KEY "docuri"
 #define ABOUT_URL_PREFIX "about:"
 
-qint64 current_timestamp(QTouchEvent *aEvent)
+static qint64 current_timestamp(QTouchEvent *aEvent)
 {
     if (aEvent) {
         return aEvent->timestamp();
@@ -81,7 +81,8 @@ qint64 current_timestamp(QTouchEvent *aEvent)
 }
 
 // Map window size to orientation.
-QSize contentWindowSize(const QMozWindow *window) {
+static QSize contentWindowSize(const QMozWindow *window)
+{
     Q_ASSERT(window);
 
     Qt::ScreenOrientation orientation = window->pendingOrientation();

--- a/src/qmozview_p.cpp
+++ b/src/qmozview_p.cpp
@@ -102,6 +102,7 @@ QMozViewPrivate::QMozViewPrivate(IMozQViewIface *aViewIface, QObject *publicPtr)
     , mParentID(0)
     , mParentBrowsingContext(0)
     , mPrivateMode(false)
+    , mHidden(false)
     , mDesktopMode(false)
     , mActive(false)
     , mLoaded(false)
@@ -162,6 +163,7 @@ QMozViewPrivate::QMozViewPrivate(IMozQViewIface *aViewIface, QObject *publicPtr)
     , mAutoCompleteActive(false)
     , mAutoCompleteList()
     , mDirtyState(0)
+    , mPendingFromExternal(false)
 {
     loadFrameScript(QStringLiteral("chrome://embedlite/content/embedhelper.js"));
     addMessageListener(RUN_JAVASCRIPT_REPLY);

--- a/src/qmozview_p.cpp
+++ b/src/qmozview_p.cpp
@@ -1130,11 +1130,10 @@ void QMozViewPrivate::OnFirstPaint(int32_t aX, int32_t aY)
 void QMozViewPrivate::OnScrolledAreaChanged(unsigned int aWidth, unsigned int aHeight)
 {
     // Normally these come from HandleScrollEvent but for some documents no such event is generated.
+    const float contentResolution = contentWindowSize(mMozWindow).width() / aWidth;
 
-    const float contentResoution = contentWindowSize(mMozWindow).width() / aWidth;
-
-    if (!qFuzzyIsNull(contentResoution) && contentResoution != mContentResolution) {
-        mContentResolution = contentResoution;
+    if (!qFuzzyIsNull(contentResolution) && contentResolution != mContentResolution) {
+        mContentResolution = contentResolution;
         mViewIface->resolutionChanged();
     }
 
@@ -1244,17 +1243,18 @@ void QMozViewPrivate::OnDynamicToolbarHeightChanged()
 
 bool QMozViewPrivate::HandleScrollEvent(const gfxRect &aContentRect, const gfxSize &aScrollableSize)
 {
-    if (mContentRect.x() != aContentRect.x || mContentRect.y() != aContentRect.y ||
-            mContentRect.width() != aContentRect.width ||
-            mContentRect.height() != aContentRect.height) {
+    if (mContentRect.x() != aContentRect.x
+            || mContentRect.y() != aContentRect.y
+            || mContentRect.width() != aContentRect.width
+            || mContentRect.height() != aContentRect.height) {
         mContentRect.setRect(aContentRect.x, aContentRect.y, aContentRect.width, aContentRect.height);
         mViewIface->viewAreaChanged();
     }
 
-    float contentResoution = contentWindowSize(mMozWindow).width() / aContentRect.width;
-    if (!qFuzzyIsNull(contentResoution)) {
-        if (mContentResolution != contentResoution) {
-            mContentResolution = contentResoution;
+    float contentResolution = contentWindowSize(mMozWindow).width() / aContentRect.width;
+    if (!qFuzzyIsNull(contentResolution)) {
+        if (mContentResolution != contentResolution) {
+            mContentResolution = contentResolution;
             mViewIface->resolutionChanged();
         }
         updateScrollArea(

--- a/src/qmozview_p.cpp
+++ b/src/qmozview_p.cpp
@@ -86,11 +86,13 @@ static QSize contentWindowSize(const QMozWindow *window)
     Q_ASSERT(window);
 
     Qt::ScreenOrientation orientation = window->pendingOrientation();
-    QSize s = window->size();
-    if (orientation == Qt::LandscapeOrientation || orientation == Qt::InvertedLandscapeOrientation) {
-        s.transpose();
+    QSize size = window->size();
+    if ((qApp->primaryScreen()->primaryOrientation() == Qt::PortraitOrientation)
+            == (orientation == Qt::LandscapeOrientation || orientation == Qt::InvertedLandscapeOrientation)) {
+        size.transpose();
     }
-    return s;
+
+    return size;
 }
 
 QMozViewPrivate::QMozViewPrivate(IMozQViewIface *aViewIface, QObject *publicPtr)

--- a/src/qmozview_p.h
+++ b/src/qmozview_p.h
@@ -263,6 +263,4 @@ protected:
     QStringList mPendingFrameScripts;
 };
 
-qint64 current_timestamp(QTouchEvent *);
-
 #endif /* qmozview_p_h */


### PR DESCRIPTION
The code was assuming all displays are native portrait and thus on landscape displays the size tranposes got wrong, ending up with the resolution property reported wrong and then browser drawing the selection handles wrong.

Fixes also some variable name typos, uninitialized member variables and such.