### PR TITLE
Adjust exit handling and re-enable full shutdown on unit tests

### DIFF
--- a/src/geckoworker.cpp
+++ b/src/geckoworker.cpp
@@ -25,10 +25,7 @@ void GeckoWorker::doWork()
 void GeckoWorker::quit()
 {
     printf("Call EmbedLiteApp::StopChildThread()\n");
-    // TODO : Check the order of destruction of EmbedLiteApp & QtMozEmbed.
-    // Causes segfault upon exit and might be that EmbedLiteApp has already
-    // stopped child thread.
-    // mApp->StopChildThread();
+    mApp->StopChildThread();
     deleteLater();
     sender()->deleteLater();
     mApp = nullptr;

--- a/tests/qmlmoztestrunner/main.cpp
+++ b/tests/qmlmoztestrunner/main.cpp
@@ -93,7 +93,9 @@ int main(int argc, char **argv)
 
     // in case there are problems in shutdown (tricky business!), avoid making all the
     // tests failing and rather have a separate test for that
-    if (qgetenv("FULL_SHUTDOWN").length() == 0) {
+    QByteArray fullShutdown = qgetenv("FULL_SHUTDOWN");
+    if (fullShutdown == "0" || fullShutdown == "false") {
+        qWarning() << "FULL_SHUTDOWN disabled, doing early exit";
         _exit(ret);
     }
 

--- a/tests/test-definition/tests.xml
+++ b/tests/test-definition/tests.xml
@@ -14,7 +14,7 @@
                <step>cd /opt/tests/qtmozembed/auto/desktop-qt5/context &amp;&amp; ../../run-tests.sh</step>
            </case>
            <case manual="false" name="unittests-basicview">
-               <step>cd /opt/tests/qtmozembed/auto/desktop-qt5/basicview &amp;&amp; FULL_SHUTDOWN=1 ../../run-tests.sh</step>
+               <step>cd /opt/tests/qtmozembed/auto/desktop-qt5/basicview &amp;&amp; ../../run-tests.sh</step>
            </case>
            <case manual="false" name="unittests-view">
                <step>cd /opt/tests/qtmozembed/auto/desktop-qt5/view &amp;&amp; ../../run-tests.sh</step>


### PR DESCRIPTION
Depends on https://github.com/sailfishos/gecko-dev/pull/172

With these I'm not getting anymore segfault upon exit neither on unit tests or running sailfish-browser from the command line.