### PR TITLE
Adapt QtMozEmbed for ESR115 WebRender

### DIFF
--- a/rpm/qtmozembed-qt5.spec
+++ b/rpm/qtmozembed-qt5.spec
@@ -1,4 +1,4 @@
-%global min_xulrunner_version 115.35.0
+%global min_xulrunner_version 115.35.1
 
 %define system_nspr       1
 %define system_pixman     1

--- a/rpm/qtmozembed-qt5.spec
+++ b/rpm/qtmozembed-qt5.spec
@@ -1,11 +1,11 @@
-%global min_xulrunner_version 90.9.1
+%global min_xulrunner_version 115.35.0
 
 %define system_nspr       1
 %define system_pixman     1
 
 Name:       qtmozembed-qt5
 Summary:    Qt embeddings for Gecko
-Version:    1.53.9
+Version:    1.56.0
 Release:    1
 License:    MPLv2.0
 URL:        https://github.com/sailfishos/qtmozembed/
@@ -29,7 +29,7 @@ BuildRequires:  qt5-qttools
 BuildRequires:  pkgconfig(systemsettings) >= 0.5.25
 Requires:       xulrunner-qt5 >= %{min_xulrunner_version}
 Requires:       nemo-qml-plugin-systemsettings >= 0.5.25
-Requires:       embedlite-components-qt5 >= 1.22.32
+Requires:       embedlite-components-qt5 >= 2.0.0
 
 %{!?qtc_qmake5:%define qtc_qmake5 %qmake5}
 %{!?qtc_make:%define qtc_make make}

--- a/src/qmessagepump.cpp
+++ b/src/qmessagepump.cpp
@@ -56,11 +56,16 @@ bool MessagePumpQt::event(QEvent *e)
 
 void MessagePumpQt::handleDispatch()
 {
+    if (!mState) {
+        return;
+    }
+
     if (mState->should_quit) {
         return;
     }
 
-    if (mEventLoopPrivate->DoWork(mState->delegate)) {
+    bool didWork = mEventLoopPrivate->DoWork(mState->delegate);
+    if (didWork) {
         // there might be more, see more_work_is_plausible
         // variable above, that's why we ScheduleWork() to keep going.
         scheduleWorkLocal();
@@ -70,11 +75,13 @@ void MessagePumpQt::handleDispatch()
         return;
     }
 
-    bool doIdleWork = !mEventLoopPrivate->DoDelayedWork(mState->delegate);
+    bool didDelayedWork = mEventLoopPrivate->DoDelayedWork(mState->delegate);
+    bool doIdleWork = !didDelayedWork;
     scheduleDelayedIfNeeded();
 
     if (doIdleWork) {
-        if (mEventLoopPrivate->DoIdleWork(mState->delegate)) {
+        bool didIdleWork = mEventLoopPrivate->DoIdleWork(mState->delegate);
+        if (didIdleWork) {
             scheduleWorkLocal();
         }
     }

--- a/src/qmessagepump.h
+++ b/src/qmessagepump.h
@@ -11,15 +11,22 @@
 #include <QVariant>
 #include <QStringList>
 
+#ifndef Q_MOC_RUN
 #include "mozilla/embedlite/EmbedLiteMessagePump.h"
+#endif
 
 namespace mozilla {
 namespace embedlite {
 class EmbedLiteApp;
+class EmbedLiteMessagePump;
+class EmbedLiteMessagePumpListener;
 }
 }
 
-class MessagePumpQt : public QObject, public mozilla::embedlite::EmbedLiteMessagePumpListener
+class MessagePumpQt : public QObject
+#ifndef Q_MOC_RUN
+    , public mozilla::embedlite::EmbedLiteMessagePumpListener
+#endif
 {
     Q_OBJECT
 

--- a/src/qmozcontext.cpp
+++ b/src/qmozcontext.cpp
@@ -137,18 +137,6 @@ QMozContextPrivate::~QMozContextPrivate()
 
 bool QMozContextPrivate::ExecuteChildThread()
 {
-    if (!getenv("GECKO_THREAD")) {
-        qCDebug(lcEmbedLiteExt) << "Execute in child Native thread:" << (void *)mThread;
-        GeckoWorker *worker = new GeckoWorker(mApp);
-
-        connect(mThread, &QThread::started, worker, &GeckoWorker::doWork);
-        connect(mThread, &QThread::finished, worker, &GeckoWorker::quit);
-        worker->moveToThread(mThread);
-
-        mThread->setObjectName("GeckoWorkerThread");
-        mThread->start(QThread::NormalPriority);
-        return true;
-    }
     return false;
 }
 

--- a/src/qmozcontext_p.h
+++ b/src/qmozcontext_p.h
@@ -20,13 +20,18 @@
 #include <QVariant>
 
 #include "qmozwindow.h"
+
+#ifndef Q_MOC_RUN
 #include "mozilla/embedlite/EmbedLiteApp.h"
+#endif
 
 class QMozViewCreator;
 class MessagePumpQt;
 
 namespace mozilla {
 namespace embedlite {
+class EmbedLiteApp;
+class EmbedLiteAppListener;
 class EmbedLiteView;
 class EmbedLiteMessagePump;
 }
@@ -34,7 +39,10 @@ class EmbedLiteMessagePump;
 
 using namespace mozilla::embedlite;
 
-class QMozContextPrivate : public QObject, public EmbedLiteAppListener
+class QMozContextPrivate : public QObject
+#ifndef Q_MOC_RUN
+    , public EmbedLiteAppListener
+#endif
 {
     Q_OBJECT
 public:

--- a/src/qmozembed.pri
+++ b/src/qmozembed.pri
@@ -23,10 +23,6 @@ QMAKE_CXXFLAGS += -I $$GECKO_INCLUDE_DIR -include mozilla-config.h
 unix:QMAKE_CXXFLAGS += -fno-short-wchar -fPIC
 DEFINES += XPCOM_GLUE=1 XPCOM_GLUE_USE_NSPR=1 MOZ_GLUE_IN_PROGRAM=1
 
-!isEmpty(ENABLE_GLX) {
-    DEFINES += ENABLE_GLX
-}
-
 #INCLUDEPATH += $$GECKO_INCLUDE_DIR/nspr /usr/include/nspr4
 contains(CONFIG, with-system-nspr) {
     INCLUDEPATH += $$system(pkg-config --cflags-only-I nspr)

--- a/src/qmozembed.pri
+++ b/src/qmozembed.pri
@@ -16,6 +16,11 @@ isEmpty(OBJ_PATH) {
   message($$BIN_DIR - binary dir)
 }
 
+!isEmpty(RUNTIME_GRE_HOME) {
+  BIN_DIR=$$RUNTIME_GRE_HOME
+  message(Runtime GRE home defined $$BIN_DIR)
+}
+
 CONFIG += \
     egl
 

--- a/src/qmozextmaterialnode.cpp
+++ b/src/qmozextmaterialnode.cpp
@@ -133,7 +133,9 @@ void MozMaterialNode::preprocess()
                 geometryRect.setHeight(textureSize.height());
             }
         } else if (height < textureSize.height()) {
-            textureRect.setHeight(textureRect.height() * height / textureSize.height());
+            const qreal croppedHeight = textureRect.height() * height / textureSize.height();
+            textureRect.setY(textureRect.y() + textureRect.height() - croppedHeight);
+            textureRect.setHeight(croppedHeight);
         }
 
         // WebRender renders into a GL framebuffer, whose EGLImage has a

--- a/src/qmozextmaterialnode.cpp
+++ b/src/qmozextmaterialnode.cpp
@@ -136,6 +136,15 @@ void MozMaterialNode::preprocess()
             textureRect.setHeight(textureRect.height() * height / textureSize.height());
         }
 
+        // WebRender renders into a GL framebuffer, whose EGLImage has a
+        // bottom-left texture origin. Qt's scene graph coordinates are
+        // top-left based, so define the logical corners with Y flipped before
+        // applying the existing content-orientation rotation.
+        const QPointF topLeft = textureRect.bottomLeft();
+        const QPointF bottomLeft = textureRect.topLeft();
+        const QPointF topRight = textureRect.bottomRight();
+        const QPointF bottomRight = textureRect.topRight();
+
         // and then texture coordinates
         int rotation = qApp->primaryScreen()->angleBetween(m_orientation, qApp->primaryScreen()->primaryOrientation());
         switch (rotation) {
@@ -143,37 +152,37 @@ void MozMaterialNode::preprocess()
             updateRectGeometry(
                         &m_geometry,
                         geometryRect,
-                        textureRect.topRight(),
-                        textureRect.topLeft(),
-                        textureRect.bottomRight(),
-                        textureRect.bottomLeft());
+                        topRight,
+                        topLeft,
+                        bottomRight,
+                        bottomLeft);
             break;
         case 180:
             updateRectGeometry(
                         &m_geometry,
                         geometryRect,
-                        textureRect.bottomRight(),
-                        textureRect.topRight(),
-                        textureRect.bottomLeft(),
-                        textureRect.topLeft());
+                        bottomRight,
+                        topRight,
+                        bottomLeft,
+                        topLeft);
             break;
         case 270:
             updateRectGeometry(
                         &m_geometry,
                         geometryRect,
-                        textureRect.bottomLeft(),
-                        textureRect.bottomRight(),
-                        textureRect.topLeft(),
-                        textureRect.topRight());
+                        bottomLeft,
+                        bottomRight,
+                        topLeft,
+                        topRight);
             break;
         default:
             updateRectGeometry(
                         &m_geometry,
                         geometryRect,
-                        textureRect.topLeft(),
-                        textureRect.bottomLeft(),
-                        textureRect.topRight(),
-                        textureRect.bottomRight());
+                        topLeft,
+                        bottomLeft,
+                        topRight,
+                        bottomRight);
             break;
         }
     }

--- a/src/qmozexttexture.cpp
+++ b/src/qmozexttexture.cpp
@@ -14,8 +14,6 @@
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 
-#include <QDebug>
-
 QMozExtTexture::QMozExtTexture()
 {
 }

--- a/src/qmozopenglwebpage.cpp
+++ b/src/qmozopenglwebpage.cpp
@@ -24,6 +24,11 @@
 
 #define LOG_COMPONENT "QMozOpenGLWebPage"
 
+static QMozViewPrivate *createViewPrivate(QMozOpenGLWebPage *webPage)
+{
+    return new QMozViewPrivate(new IMozQView<QMozOpenGLWebPage>(*webPage), webPage);
+}
+
 /*!
     \fn void QMozOpenGLWebPage::afterRendering()
 
@@ -43,11 +48,11 @@
 /*!
     \fn void QMozOpenGLWebPage::QMozOpenGLWebPage(QObject *parent)
 
-    In order to use this, embedlite.compositor.external_gl_context preference needs to be set.
+    This legacy API is separate from the WebRender browser texture path.
 */
 QMozOpenGLWebPage::QMozOpenGLWebPage(QObject *parent)
     : QObject(parent)
-    , d(new QMozViewPrivate(new IMozQView<QMozOpenGLWebPage>(*this), this))
+    , d(createViewPrivate(this))
     , mCompleted(false)
     , mThrottlePainting(false)
 {
@@ -172,6 +177,9 @@ void QMozOpenGLWebPage::setMozWindow(QMozWindow *window)
     d->setMozWindow(window);
 
     if (window) {
+        if (d->mSize.isEmpty() && !window->size().isEmpty()) {
+            d->setSize(window->size());
+        }
         window->setSize(d->mSize.toSize());
     }
 

--- a/src/qmozopenglwebpage.cpp
+++ b/src/qmozopenglwebpage.cpp
@@ -497,6 +497,16 @@ void QMozOpenGLWebPage::setMargins(QMargins margins)
     d->setMargins(margins, true);
 }
 
+QMargins QMozOpenGLWebPage::safeAreaInsets() const
+{
+    return d->mSafeAreaInsets;
+}
+
+void QMozOpenGLWebPage::setSafeAreaInsets(QMargins insets)
+{
+    d->setSafeAreaInsets(insets);
+}
+
 void QMozOpenGLWebPage::loadHtml(const QString &html, const QUrl &baseUrl)
 {
     Q_UNUSED(baseUrl);

--- a/src/qmozview_defined_wrapper.h
+++ b/src/qmozview_defined_wrapper.h
@@ -139,6 +139,8 @@ Q_DECLARE_METATYPE(QMozReturnValue) \
     void setDynamicToolbarHeight(int height); \
     QMargins margins() const; \
     void setMargins(QMargins); \
+    QMargins safeAreaInsets() const; \
+    void setSafeAreaInsets(QMargins); \
     Q_INVOKABLE void scrollTo(int x, int y); \
     Q_INVOKABLE void scrollBy(int x, int y); \
     QMozSecurity *security(); \
@@ -213,6 +215,7 @@ Q_DECLARE_METATYPE(QMozReturnValue) \
     void chromeGestureThresholdChanged(); \
     void dynamicToolbarHeightChanged(); \
     void marginsChanged(); \
+    void safeAreaInsetsChanged(); \
     void desktopModeChanged(); \
     void parentIdChanged(); \
     void uniqueIdChanged(); \

--- a/src/qmozview_p.cpp
+++ b/src/qmozview_p.cpp
@@ -407,6 +407,40 @@ void QMozViewPrivate::updateMoving(bool moving)
 
 void QMozViewPrivate::reset()
 {
+    if (mMozWindow) {
+        mMozWindow->clearPlatformImage();
+    }
+
+    const bool viewAreaChanged = !mContentRect.isNull();
+    const bool contentWidthChanged = !qFuzzyIsNull(mScrollableSize.width());
+    const bool contentHeightChanged = !qFuzzyIsNull(mScrollableSize.height());
+    const bool scrollableOffsetChanged = !mScrollableOffset.isNull();
+    const bool atXBeginningChanged = mAtXBeginning;
+    const bool atXEndChanged = mAtXEnd;
+    const bool atYBeginningChanged = mAtYBeginning;
+    const bool atYEndChanged = mAtYEnd;
+    const bool resolutionChanged = !qFuzzyIsNull(mContentResolution);
+
+    mContentRect = QRectF();
+    mScrollableSize = QSizeF();
+    mScrollableOffset = QPointF();
+    mAtXBeginning = false;
+    mAtXEnd = false;
+    mAtYBeginning = false;
+    mAtYEnd = false;
+    mContentResolution = 0.0f;
+
+    if (viewAreaChanged) mViewIface->viewAreaChanged();
+    if (contentWidthChanged) mViewIface->contentWidthChanged();
+    if (contentHeightChanged) mViewIface->contentHeightChanged();
+    if (contentWidthChanged || contentHeightChanged) mViewIface->scrollableSizeChanged();
+    if (scrollableOffsetChanged) mViewIface->scrollableOffsetChanged();
+    if (atXBeginningChanged) mViewIface->atXBeginningChanged();
+    if (atXEndChanged) mViewIface->atXEndChanged();
+    if (atYBeginningChanged) mViewIface->atYBeginningChanged();
+    if (atYEndChanged) mViewIface->atYEndChanged();
+    if (resolutionChanged) mViewIface->resolutionChanged();
+
     if (mIsPainted) {
         mIsPainted = false;
         mViewIface->firstPaint(-1, -1);

--- a/src/qmozview_p.cpp
+++ b/src/qmozview_p.cpp
@@ -14,6 +14,7 @@
 #include <QJSEngine>
 #include <QJsonDocument>
 #include <QJsonParseError>
+#include <QTimer>
 #include <QTouchEvent>
 #include <QQuickWindow>
 #include <QScreen>
@@ -754,12 +755,17 @@ void QMozViewPrivate::inputMethodEvent(QInputMethodEvent *event)
             qGuiApp->inputMethod()->reset();
 
         } else {
-            if (mPreedit || event->commitString().isEmpty() || event->commitString().size() > 1) {
+            if (mPreedit || !event->commitString().isEmpty()
+                    || !event->preeditString().isEmpty()
+                    || event->replacementLength() > 0) {
                 mView->SendTextEvent(event->commitString().toUtf8().data(), event->preeditString().toUtf8().data(),
                                      event->replacementStart(), event->replacementLength());
-            } else {
-                mView->SendKeyPress(0, 0, charCode);
-                mView->SendKeyRelease(0, 0, charCode);
+                if (event->commitString().isEmpty() && !event->preeditString().isEmpty()) {
+                    QInputMethod *inputContext = qGuiApp->inputMethod();
+                    if (inputContext) {
+                        QTimer::singleShot(0, inputContext, &QInputMethod::commit);
+                    }
+                }
             }
         }
     }

--- a/src/qmozview_p.cpp
+++ b/src/qmozview_p.cpp
@@ -115,6 +115,7 @@ QMozViewPrivate::QMozViewPrivate(IMozQViewIface *aViewIface, QObject *publicPtr)
     , mBottomMargin(0.0)
     , mDynamicToolbarHeight(0)
     , mMargins(0, 0, 0, 0)
+    , mSafeAreaInsets(0, 0, 0, 0)
     , mTempTexture(nullptr)
     , mEnabled(true)
     , mChromeGestureEnabled(true)
@@ -962,6 +963,12 @@ void QMozViewPrivate::ViewInitialized()
         mDirtyState &= ~DirtyMargin;
     }
 
+    if (mDirtyState & DirtySafeAreaInsets) {
+        mView->SetSafeAreaInsets(mSafeAreaInsets.top(), mSafeAreaInsets.right(), mSafeAreaInsets.bottom(), mSafeAreaInsets.left());
+        mViewIface->safeAreaInsetsChanged();
+        mDirtyState &= ~DirtySafeAreaInsets;
+    }
+
     if (!mHttpUserAgent.isEmpty()) {
         mView->SetHttpUserAgent((const char16_t *)mHttpUserAgent.utf16());
     }
@@ -1005,6 +1012,20 @@ void QMozViewPrivate::setMargins(const QMargins &margins, bool updateTopBottom)
             mViewIface->marginsChanged();
         } else {
             mDirtyState |= DirtyMargin;
+        }
+    }
+}
+
+void QMozViewPrivate::setSafeAreaInsets(const QMargins &insets)
+{
+    if (insets != mSafeAreaInsets) {
+        mSafeAreaInsets = insets;
+
+        if (mViewInitialized) {
+            mView->SetSafeAreaInsets(insets.top(), insets.right(), insets.bottom(), insets.left());
+            mViewIface->safeAreaInsetsChanged();
+        } else {
+            mDirtyState |= DirtySafeAreaInsets;
         }
     }
 }

--- a/src/qmozview_p.cpp
+++ b/src/qmozview_p.cpp
@@ -176,6 +176,17 @@ QMozViewPrivate::QMozViewPrivate(IMozQViewIface *aViewIface, QObject *publicPtr)
     addMessageListener(INPUTMETHOD_RESET_INPUT_CONTEXT);
     addMessageListener(INPUTMETHOD_SET_INPUT_ATTRIBUTES);
     addMessageListener(INPUTMETHOD_RESET_INPUT_ATTRIBUTES);
+    connect(QMozEngineSettings::instance(), &QMozEngineSettings::pixelRatioChanged,
+            this, [this]() {
+        if (!mView || mDepth <= 0 || mDpi <= 0.0) {
+            return;
+        }
+        if (!mHasCompositor) {
+            mDirtyState |= DirtyScreenProperties;
+            return;
+        }
+        sendScreenProperties();
+    });
 }
 
 QMozViewPrivate::~QMozViewPrivate()
@@ -420,6 +431,27 @@ void QMozViewPrivate::setSize(const QSizeF &size)
     }
 }
 
+qreal QMozViewPrivate::screenDensity() const
+{
+    qreal density = QMozEngineSettings::instance()->pixelRatio();
+    if (density > 0.0) {
+        return density;
+    }
+
+    QScreen *screen = QGuiApplication::primaryScreen();
+    if (screen && screen->devicePixelRatio() > 0.0) {
+        return screen->devicePixelRatio();
+    }
+
+    return 1.0;
+}
+
+void QMozViewPrivate::sendScreenProperties()
+{
+    Q_ASSERT_X(mView, __PRETTY_FUNCTION__, "EmbedLiteView must be created by now");
+    mView->SetScreenProperties(mDepth, screenDensity(), mDpi);
+}
+
 void QMozViewPrivate::setScreenProperties(int depth, qreal dpi)
 {
     Q_ASSERT_X(mView, __PRETTY_FUNCTION__, "EmbedLiteView must be created by now");
@@ -428,7 +460,7 @@ void QMozViewPrivate::setScreenProperties(int depth, qreal dpi)
     if (!mHasCompositor) {
         mDirtyState |= DirtyScreenProperties;
     } else {
-        mView->SetScreenProperties(mDepth, mDpi, mDpi);
+        sendScreenProperties();
     }
 }
 
@@ -751,6 +783,12 @@ void QMozViewPrivate::setMozWindow(QMozWindow *window)
 {
     mMozWindow = window;
     if (mMozWindow) {
+        if (mSize.isEmpty() && !mMozWindow->size().isEmpty()) {
+            mSize = mMozWindow->size();
+            if (!mViewInitialized) {
+                mDirtyState |= DirtySize;
+            }
+        }
         mHasCompositor = mMozWindow->isCompositorCreated();
         connect(mMozWindow.data(), &QMozWindow::compositorCreated,
                 this, &QMozViewPrivate::onCompositorCreated);
@@ -832,7 +870,7 @@ void QMozViewPrivate::onCompositorCreated()
 {
     mHasCompositor = true;
     if (mDirtyState & DirtyScreenProperties) {
-        mView->SetScreenProperties(mDepth, mDpi, mDpi);
+        sendScreenProperties();
         mDirtyState &= ~DirtyScreenProperties;
     }
 }
@@ -870,7 +908,8 @@ void QMozViewPrivate::createView()
         Q_ASSERT(mMozWindow);
 
         EmbedLiteWindow *win = mMozWindow->d->mWindow;
-        mView = mContext->GetApp()->CreateView(win, mParentID, mParentBrowsingContext, mPrivateMode, mDesktopMode);
+        mView = mContext->GetApp()->CreateView(win, mParentID, mParentBrowsingContext,
+                                               mPrivateMode, mDesktopMode, mHidden);
         mView->SetListener(this);
         setScreenProperties(QGuiApplication::primaryScreen()->depth(),
                             QGuiApplication::primaryScreen()->physicalDotsPerInch());
@@ -901,7 +940,14 @@ void QMozViewPrivate::ViewInitialized()
         load(mPendingUrl, mPendingFromExternal);
     }
 
+    if ((mDirtyState & DirtySize) && mSize.isEmpty() && mMozWindow && !mMozWindow->size().isEmpty()) {
+        mSize = mMozWindow->size();
+    }
+
     if (mDirtyState & DirtySize) {
+        if (mMozWindow && !mSize.isEmpty()) {
+            mMozWindow->setSize(mSize.toSize());
+        }
         setSize(mSize);
         mDirtyState &= ~DirtySize;
     } else if (mMozWindow) {
@@ -1025,6 +1071,13 @@ void QMozViewPrivate::OnLoadFinished(void)
         mIsLoading = false;
         mViewIface->loadingChanged();
     }
+
+    if (mMozWindow) {
+        if (mViewInitialized && mView) {
+            mView->ScheduleUpdate();
+        }
+        mMozWindow->scheduleUpdate();
+    }
 }
 
 void QMozViewPrivate::OnWindowCloseRequested()
@@ -1130,6 +1183,12 @@ void QMozViewPrivate::OnFirstPaint(int32_t aX, int32_t aY)
 #endif
     mIsPainted = true;
     mViewIface->firstPaint(aX, aY);
+    if (mMozWindow) {
+        if (mViewInitialized && mView) {
+            mView->ScheduleUpdate();
+        }
+        mMozWindow->scheduleUpdate();
+    }
 }
 
 void QMozViewPrivate::OnScrolledAreaChanged(unsigned int aWidth, unsigned int aHeight)

--- a/src/qmozview_p.h
+++ b/src/qmozview_p.h
@@ -59,6 +59,7 @@ public:
         DirtyDynamicToolbarHeight = 0x0004,
         DirtyScreenProperties = 0x0008,
         DirtyActive = 0x0010,
+        DirtySafeAreaInsets = 0x0020,
     };
 
     Q_DECLARE_FLAGS(DirtyState, DirtyStateBit)
@@ -95,6 +96,7 @@ public:
     // Starting from here these are QMozViewPrivate methods.
     void setDynamicToolbarHeight(const int height);
     void setMargins(const QMargins &margins, bool updateTopBottom);
+    void setSafeAreaInsets(const QMargins &insets);
     void setIsFocused(bool aIsFocused);
     void setDesktopMode(bool aDesktopMode);
     void setThrottlePainting(bool aThrottle);
@@ -197,6 +199,7 @@ protected:
     qreal mBottomMargin;
     int mDynamicToolbarHeight;
     QMargins mMargins;
+    QMargins mSafeAreaInsets;
     QImage mTempBufferImage;
     QSGTexture *mTempTexture;
     bool mEnabled;

--- a/src/qmozview_p.h
+++ b/src/qmozview_p.h
@@ -23,7 +23,9 @@
 #include <QKeyEvent>
 #include <QJSValue>
 
+#ifndef Q_MOC_RUN
 #include <mozilla/embedlite/EmbedLiteView.h>
+#endif
 
 #include "qmozwindow.h"
 #include "qmozscrolldecorator.h"
@@ -37,13 +39,17 @@ class QMozWindow;
 
 namespace mozilla {
 namespace embedlite {
+class EmbedLiteView;
+class EmbedLiteViewListener;
 class EmbedTouchInput;
 class TouchPointF;
 }
 }
 
-class QMozViewPrivate : public QObject,
-    public mozilla::embedlite::EmbedLiteViewListener
+class QMozViewPrivate : public QObject
+#ifndef Q_MOC_RUN
+    , public mozilla::embedlite::EmbedLiteViewListener
+#endif
 {
     Q_OBJECT
 public:
@@ -84,7 +90,7 @@ public:
     bool HandleSingleTap(const nsIntPoint &aPoint) override;
     bool HandleDoubleTap(const nsIntPoint &aPoint) override;
     bool HandleScrollEvent(const gfxRect &aContentRect, const gfxSize &aScrollableSize) override;
-    void OnHttpUserAgentUsed(const char16_t *aHttpUserAgent);
+    void OnHttpUserAgentUsed(const char16_t *aHttpUserAgent) override;
 
     // Starting from here these are QMozViewPrivate methods.
     void setDynamicToolbarHeight(const int height);
@@ -169,6 +175,8 @@ protected:
     void doSendAsyncMessage(const QString &message, const QVariant &value);
     bool handleAsyncMessage(const QString &message, const QVariant &data);
     void clearDirtyDynamicToolbarHeight();
+    qreal screenDensity() const;
+    void sendScreenProperties();
 
     IMozQViewIface *mViewIface;
     QPointer<QObject> q;

--- a/src/qmozview_templated_wrapper.h
+++ b/src/qmozview_templated_wrapper.h
@@ -54,6 +54,7 @@ public:
     virtual void pinchingChanged() = 0;
     virtual void dynamicToolbarHeightChanged() = 0;
     virtual void marginsChanged() = 0;
+    virtual void safeAreaInsetsChanged() = 0;
     virtual void scrollableSizeChanged() = 0;
 
     virtual void desktopModeChanged() = 0;
@@ -242,6 +243,11 @@ public:
     void marginsChanged()
     {
         Q_EMIT view.marginsChanged();
+    }
+
+    void safeAreaInsetsChanged() override
+    {
+        Q_EMIT view.safeAreaInsetsChanged();
     }
 
     void contentWidthChanged()

--- a/src/qmozwindow.cpp
+++ b/src/qmozwindow.cpp
@@ -92,6 +92,11 @@ void QMozWindow::getPlatformImage(const std::function<void(void *image, int widt
     d->mWindow->GetPlatformImage(callback);
 }
 
+void QMozWindow::clearPlatformImage()
+{
+    d->mWindow->ClearPlatformImage();
+}
+
 void QMozWindow::suspendRendering()
 {
     d->mWindow->SuspendRendering();

--- a/src/qmozwindow.h
+++ b/src/qmozwindow.h
@@ -46,6 +46,8 @@ public:
 Q_SIGNALS:
     void pendingOrientationChanged(Qt::ScreenOrientation orientation);
     void orientationChangeFiltered(Qt::ScreenOrientation orientation);
+    // Retained for ABI compatibility. Gecko no longer requests an embedder GL
+    // context through this signal.
     void requestGLContext();
     void initialized();
     void released();

--- a/src/qmozwindow.h
+++ b/src/qmozwindow.h
@@ -35,6 +35,7 @@ public:
     Qt::ScreenOrientation pendingOrientation() const;
     Qt::ScreenOrientation primaryOrientation() const;
     void getPlatformImage(const std::function<void(void *image, int width, int height)> &callback);
+    void clearPlatformImage();
     void suspendRendering();
     void resumeRendering();
     void scheduleUpdate();

--- a/src/qmozwindow_p.cpp
+++ b/src/qmozwindow_p.cpp
@@ -15,22 +15,7 @@
 #include <QGuiApplication>
 #include <QScreen>
 
-#include <dlfcn.h>
-#include <EGL/egl.h>
-#if defined(ENABLE_GLX)
-#include <GL/glx.h>
-#endif
-
 #include <mozilla/embedlite/EmbedLiteWindow.h>
-
-EGLContext (EGLAPIENTRY *_eglGetCurrentContext)(void) = nullptr;
-EGLSurface (EGLAPIENTRY *_eglGetCurrentSurface)(EGLint readdraw) = nullptr;
-EGLDisplay (EGLAPIENTRY *_eglGetCurrentDisplay)(void) = nullptr;
-
-#if defined(ENABLE_GLX)
-GLXContext (*_glxGetCurrentContext)(void) = nullptr;
-GLXDrawable (*_glxGetCurrentDrawable)(void) = nullptr;
-#endif
 
 #ifndef MOZWINDOW_ORIENTATION_CHANGE_TIMEOUT
 #define MOZWINDOW_ORIENTATION_CHANGE_TIMEOUT 500
@@ -127,69 +112,6 @@ void QMozWindowPrivate::timerEvent(QTimerEvent *event)
         event->accept();
     }
 }
-
-bool QMozWindowPrivate::RequestGLContext(void *&context, void *&surface, void *&display)
-{
-    q.requestGLContext();
-
-    QString platform = qApp->platformName().toLower();
-
-    if (platform == "wayland" || platform == "wayland-egl" || platform == "eglfs") {
-        getEGLContext(context, surface, display);
-        return true;
-    }
-#if defined(ENABLE_GLX)
-    if (platform == "xcb") {
-        getGLXContext(context, surface);
-        return true;
-    }
-#endif
-
-    qCritical() << "Unsupported QPA platform type:" << platform;
-    return false;
-}
-
-void QMozWindowPrivate::getEGLContext(void *&context, void *&surface, void *&display)
-{
-    if (!_eglGetCurrentContext || !_eglGetCurrentSurface) {
-        void *handle = dlopen("libEGL.so.1", RTLD_LAZY);
-        if (!handle)
-            return;
-
-        *(void **)(&_eglGetCurrentContext) = dlsym(handle, "eglGetCurrentContext");
-        *(void **)(&_eglGetCurrentSurface) = dlsym(handle, "eglGetCurrentSurface");
-        *(void **)(&_eglGetCurrentDisplay) = dlsym(handle, "eglGetCurrentDisplay");
-
-        Q_ASSERT(_eglGetCurrentContext && _eglGetCurrentSurface && _eglGetCurrentDisplay);
-
-        dlclose(handle);
-    }
-
-    surface = _eglGetCurrentSurface(EGL_DRAW);
-    context = _eglGetCurrentContext();
-    display = _eglGetCurrentDisplay();
-}
-
-#if defined(ENABLE_GLX)
-void QMozWindowPrivate::getGLXContext(void *&context, void *&surface)
-{
-    if (!_glxGetCurrentContext || !_glxGetCurrentDrawable) {
-        void *handle = dlopen("libGL.so.1", RTLD_LAZY);
-        if (!handle)
-            return;
-
-        *(void **)(&_glxGetCurrentContext) = dlsym(handle, "glXGetCurrentContext");
-        *(void **)(&_glxGetCurrentDrawable) = dlsym(handle, "glXGetCurrentDrawable");
-
-        Q_ASSERT(_glxGetCurrentContext && _glxGetCurrentDrawable);
-
-        dlclose(handle);
-    }
-
-    surface = reinterpret_cast<void *>(_glxGetCurrentDrawable());
-    context = _glxGetCurrentContext();
-}
-#endif
 
 bool QMozWindowPrivate::setReadyToPaint(bool ready)
 {

--- a/src/qmozwindow_p.h
+++ b/src/qmozwindow_p.h
@@ -28,7 +28,6 @@ public:
 
 protected:
     // EmbedLiteWindowListener:
-    bool RequestGLContext(void *&context, void *&surface, void *&display);
     void WindowInitialized() override;
     void WindowDestroyed() override;
     void DrawOverlay(const nsIntRect &aRect) override;
@@ -40,10 +39,6 @@ private:
     friend class QMozWindow;
     friend class QMozViewPrivate;
 
-    void getEGLContext(void *&context, void *&surface, void *&display);
-#if defined(ENABLE_GLX)
-    void getGLXContext(void *&context, void *&surface);
-#endif
     bool setReadyToPaint(bool ready);
 
     QMozWindow &q;
@@ -62,4 +57,3 @@ private:
 };
 
 #endif // QMOZWINDOW_PRIVATE_H
-

--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -177,8 +177,7 @@ QSGNode * QuickMozView::updatePaintNode(QSGNode *oldNode, UpdatePaintNodeData *)
         return nullptr;
     }
 
-    const bool invalidTexture = !mComposited
-            || !d->mIsPainted
+    const bool invalidTexture = (!mComposited && !d->mIsPainted)
             || !d->mViewInitialized
             || !d->mHasCompositor
             || !d->mContext->registeredWindow()

--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -605,6 +605,16 @@ QMargins QuickMozView::margins() const
     return d->mMargins;
 }
 
+QMargins QuickMozView::safeAreaInsets() const
+{
+    return d->mSafeAreaInsets;
+}
+
+void QuickMozView::setSafeAreaInsets(QMargins insets)
+{
+    d->setSafeAreaInsets(insets);
+}
+
 Qt::ScreenOrientation QuickMozView::orientation() const
 {
     return mOrientation;


### PR DESCRIPTION
- Adapt QtMozEmbed for ESR115's offscreen WebRender EGLImage presentation path.
- Update texture refresh, sizing, density propagation, and QuickMozView texture orientation handling.
- Drop the obsolete embedder GL context request implementation.
- Forward safe-area insets to EmbedLite.
- Clear retained platform images and reset scroll state when reusing WebView instances to avoid stale content.
