### PR TITLE
[qtmozembed] Keep rendering until navigation starts. Fixes JB#64866

### DIFF
--- a/src/qmozopenglwebpage.cpp
+++ b/src/qmozopenglwebpage.cpp
@@ -535,6 +535,11 @@ void QMozOpenGLWebPage::stop()
     d->stop();
 }
 
+void QMozOpenGLWebPage::cancelPendingNavigation()
+{
+    d->cancelPendingNavigation();
+}
+
 void QMozOpenGLWebPage::reload()
 {
     d->reload();

--- a/src/qmozview_defined_wrapper.h
+++ b/src/qmozview_defined_wrapper.h
@@ -161,6 +161,7 @@ Q_DECLARE_METATYPE(QMozReturnValue) \
     void goBack(); \
     void goForward(); \
     void stop(); \
+    void cancelPendingNavigation(); \
     void reload(); \
     void load(const QString&, bool fromExternal); \
     void sendAsyncMessage(const QString &name, const QVariant &variant); \

--- a/src/qmozview_p.cpp
+++ b/src/qmozview_p.cpp
@@ -515,7 +515,6 @@ void QMozViewPrivate::goBack()
     if (!mViewInitialized)
         return;
 
-    reset();
     mView->GoBack(false, true);
 }
 
@@ -524,7 +523,6 @@ void QMozViewPrivate::goForward()
     if (!mViewInitialized)
         return;
 
-    reset();
     mView->GoForward(false, true);
 }
 
@@ -543,7 +541,6 @@ void QMozViewPrivate::reload()
     if (!mPendingUrl.isEmpty()) {
         load(mPendingUrl, mPendingFromExternal);
     } else {
-        reset();
         mView->Reload(false);
     }
 }
@@ -563,7 +560,6 @@ void QMozViewPrivate::load(const QString &url, bool fromExternal)
     qCDebug(lcEmbedLiteExt) << "url:" << url.toUtf8().data();
 #endif
     mProgress = 0;
-    reset();
     mView->LoadURL(url.toUtf8().data(), fromExternal);
 
     if (mPendingUrl != url) {
@@ -1107,6 +1103,8 @@ void QMozViewPrivate::OnLoadStarted(const char *aLocation)
 {
     Q_UNUSED(aLocation);
 
+    // Keep the current document painted until a requested navigation starts.
+    // The request may still be cancelled by a beforeunload prompt.
     reset();
 
     if (!mIsLoading) {

--- a/src/qmozview_p.cpp
+++ b/src/qmozview_p.cpp
@@ -533,6 +533,18 @@ void QMozViewPrivate::stop()
     mView->StopLoad();
 }
 
+void QMozViewPrivate::cancelPendingNavigation()
+{
+    // Gecko owns the navigation; discard the provisional URL after the
+    // embedding has rejected the request.
+    if (mPendingUrl.isEmpty() || mUrl.isEmpty())
+        return;
+
+    mPendingUrl.clear();
+    mPendingFromExternal = false;
+    mViewIface->urlChanged();
+}
+
 void QMozViewPrivate::reload()
 {
     if (!mViewInitialized)
@@ -1120,9 +1132,7 @@ void QMozViewPrivate::OnLoadFinished(void)
     // if loading has stopped before location change, restore back
     // previous none empty url. Normally OnLocationChange clears pending url.
     if (!mPendingUrl.isEmpty() && !mUrl.isEmpty() && (mUrl != mPendingUrl)) {
-        mPendingUrl.clear();
-        mPendingFromExternal = false;
-        mViewIface->urlChanged();
+        cancelPendingNavigation();
     }
 
     if (mIsLoading) {

--- a/src/qmozview_p.h
+++ b/src/qmozview_p.h
@@ -126,6 +126,7 @@ public:
     void goBack();
     void goForward();
     void stop();
+    void cancelPendingNavigation();
     void reload();
     void load(const QString &url, bool fromExternal);
     void loadFrameScript(const QString &frameScript);

--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -721,6 +721,11 @@ void QuickMozView::stop()
     d->stop();
 }
 
+void QuickMozView::cancelPendingNavigation()
+{
+    d->cancelPendingNavigation();
+}
+
 void QuickMozView::reload()
 {
     d->reload();


### PR DESCRIPTION
Navigation requests can be rejected by a beforeunload prompt. Resetting the view before asking Gecko to navigate clears its painted state and lets Browser suspend rendering. When the request is rejected, no new document arrives to resume rendering.

Reset the view only from OnLoadStarted, which already handles every successful document navigation.