### PR TITLE
[qtmozembed] Fix prompt unit test response. JB#64866

### DIFF
--- a/tests/auto/desktop-qt5/promptbasic/tst_prompt.qml
+++ b/tests/auto/desktop-qt5/promptbasic/tst_prompt.qml
@@ -50,8 +50,8 @@ TestWindow {
                 }
 
                 responseMessages[appWindow.testCaseNum] = {
-                    winid: data.winid,
-                    checkval: true,
+                    winId: data.winId,
+                    checkvalue: true,
                     accepted: true,
                     promptvalue: responsePrompt
                 }


### PR DESCRIPTION
The ESR115 prompt bridge now matches replies to their originating view. Use the current winId and checkvalue field names so the test response is accepted and the synchronous prompt can complete.