### PR TITLE
[qtmozembed] Keep prompt test dialogs enabled. Fixes JB#64866

### DIFF
--- a/tests/auto/desktop-qt5/promptbasic/tst_prompt.qml
+++ b/tests/auto/desktop-qt5/promptbasic/tst_prompt.qml
@@ -51,7 +51,7 @@ TestWindow {
 
                 responseMessages[appWindow.testCaseNum] = {
                     winId: data.winId,
-                    checkvalue: true,
+                    checkvalue: false,
                     accepted: true,
                     promptvalue: responsePrompt
                 }


### PR DESCRIPTION
The prompt test runs three dialogs in rapid succession. Return an unchecked prevent-dialogs value so completing the first prompt does not suppress the remaining cases.